### PR TITLE
Revert "fix(docker-image): Update actions-runner-controller-charts/gha-runner-scale-set-controller Docker tag to v0.9.3"

### DIFF
--- a/kubernetes/main/apps/system-controllers/actions-runner-controller/operator/app/helmrelease.yaml
+++ b/kubernetes/main/apps/system-controllers/actions-runner-controller/operator/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: actions-runner-controller-charts/gha-runner-scale-set-controller
-      version: 0.9.3
+      version: 0.9.2
       sourceRef:
         kind: HelmRepository
         name: actions-runner-controller


### PR DESCRIPTION
Reverts kalenarndt/bmrf-ops#199